### PR TITLE
Make required CI fork-safe and isolate Vitest Web Storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,16 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      unit_tests: ${{ steps.unit_tests.outcome }}
+      integration_tests: ${{ steps.integration_tests.outcome }}
+      report_validation: ${{ steps.validate_test_reports.outcome }}
+      report_publishing: ${{ steps.publish_test_report.outcome }}
+      detail_publishing: ${{ steps.publish_test_details.outcome }}
     services:
       postgres:
         image: postgres:16
@@ -98,7 +103,9 @@ jobs:
           fail_on_failure: true
           fail_on_parse_error: true
           require_tests: true
-          annotate_only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          # Keep the required contexts as native job checks. This mode emits
+          # annotations without requiring fork code to create check runs.
+          annotate_only: true
 
       - name: Publish test file and failure details
         id: publish_test_details
@@ -137,3 +144,41 @@ jobs:
           exit "$failed"
 
       - run: npm run build
+
+  unit-coverage:
+    name: Unit & coverage
+    needs: verify
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce unit and reporting results
+        shell: bash
+        env:
+          TEST_OUTCOME: ${{ needs.verify.outputs.unit_tests }}
+          REPORT_VALIDATION_OUTCOME: ${{ needs.verify.outputs.report_validation }}
+          REPORT_PUBLISH_OUTCOME: ${{ needs.verify.outputs.report_publishing }}
+          DETAILS_PUBLISH_OUTCOME: ${{ needs.verify.outputs.detail_publishing }}
+        run: |
+          test "$TEST_OUTCOME" = success
+          test "$REPORT_VALIDATION_OUTCOME" = success
+          test "$REPORT_PUBLISH_OUTCOME" = success
+          test "$DETAILS_PUBLISH_OUTCOME" = success
+
+  postgres-integration:
+    name: PostgreSQL integration
+    needs: verify
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce integration and reporting results
+        shell: bash
+        env:
+          TEST_OUTCOME: ${{ needs.verify.outputs.integration_tests }}
+          REPORT_VALIDATION_OUTCOME: ${{ needs.verify.outputs.report_validation }}
+          REPORT_PUBLISH_OUTCOME: ${{ needs.verify.outputs.report_publishing }}
+          DETAILS_PUBLISH_OUTCOME: ${{ needs.verify.outputs.detail_publishing }}
+        run: |
+          test "$TEST_OUTCOME" = success
+          test "$REPORT_VALIDATION_OUTCOME" = success
+          test "$REPORT_PUBLISH_OUTCOME" = success
+          test "$DETAILS_PUBLISH_OUTCOME" = success

--- a/README.md
+++ b/README.md
@@ -214,6 +214,39 @@ npm run test:integration
 npm run build
 ```
 
+### Pull request CI parity
+
+Pull request CI uses Node.js 24.x, npm, and PostgreSQL 16. With Node.js 24.x
+installed, run the same gated commands locally from a clean checkout:
+
+```bash
+docker compose --profile test up -d --wait postgres-test
+export TEST_DATABASE_URL=postgresql://itestflow:itestflow@localhost:5433/itestflow_test
+export APP_ENCRYPTION_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+export SESSION_SECRET=local-ci-session-secret
+npm ci
+npm run db:migrate:test
+npm run typecheck
+npm run lint
+npm run test:coverage
+npm run test:coverage:integration
+npm run build
+```
+
+The protected `main` branch requires the stable checks `verify`,
+`Unit & coverage`, and `PostgreSQL integration`. These are native job checks,
+so they are reported for repository branches and forks alike. The jobs fail on
+a failed test lane or missing or invalid test report; a missing or failing test
+result cannot be treated as a passing build.
+
+Pull requests from public forks use the same `pull_request` workflow, but
+GitHub may hold a run in `action_required` until a maintainer approves it. A
+maintainer should review the pull request's **Files changed** tab—especially
+changes under `.github/workflows/`—then open **Awaiting approval** in the merge
+status panel and select **Approve workflows to run**. Fork runs receive a
+read-only `GITHUB_TOKEN` and no repository secrets. Do not bypass this review
+by running fork code from a privileged `pull_request_target` workflow.
+
 `test:unit` and `test:coverage` need no database, browser, internet, Azure DevOps
 connection, or LLM credentials. `test:integration` requires `TEST_DATABASE_URL` and a
 migrated disposable PostgreSQL database. Start the bundled test database with

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,5 +12,9 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  }
   vi.useRealTimers();
 });

--- a/src/test/web-storage-isolation.test.ts
+++ b/src/test/web-storage-isolation.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+describe("Web Storage test isolation", () => {
+  it("provides local and session storage", () => {
+    expect(window.localStorage).toBeDefined();
+    expect(window.sessionStorage).toBeDefined();
+
+    window.localStorage.setItem("test-sentinel", "local");
+    window.sessionStorage.setItem("test-sentinel", "session");
+
+    expect(window.localStorage.getItem("test-sentinel")).toBe("local");
+    expect(window.sessionStorage.getItem("test-sentinel")).toBe("session");
+  });
+
+  it("starts the next test with empty storage", () => {
+    expect(window.localStorage.getItem("test-sentinel")).toBeNull();
+    expect(window.sessionStorage.getItem("test-sentinel")).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Node 26 exposes process-global Web Storage that shadows jsdom's isolated
+    // implementation unless it is disabled in each Vitest worker.
+    execArgv: ["--no-experimental-webstorage"],
     // Test-file SELECTION lives in the lane configs, NOT here: vitest.unit.config.ts
     // includes all non-DB tests; vitest.integration.config.ts includes only *.db.test.*.
     // Keeping `include` out of the base is deliberate — mergeConfig CONCATENATES arrays,


### PR DESCRIPTION
## Summary

- make the existing required CI contexts native jobs so repository and approved fork pull requests report the same stable checks
- keep fork execution on the least-privilege `pull_request` boundary and document the maintainer approval flow
- disable Node process-global Web Storage inside Vitest workers so jsdom owns isolated browser storage
- clear jsdom local/session storage between tests and add a focused regression

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage` — 232 files, 1,956 tests; coverage floor passed
- `npm run build`
- workflow YAML/required-context structural assertions
- `docker compose --profile test config --quiet`
- independent adversarial review: zero findings

Closes #157
Closes #158