### PR TITLE
fix(ci): update Node 24 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
       SESSION_SECRET: ci-session-secret
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,12 @@ graphify-out/
 !.claude/
 !.claude/**
 .claude/settings.local.json
+/.claude/skills/*
+!/.claude/skills/chaos-engine/
+!/.claude/skills/chaos-engine/**
 !.codex/
 !.codex/**
+/.codex/skills/
 !.grok/
 !.grok/hooks/
 !.grok/hooks/*.json


### PR DESCRIPTION
## Summary

- Upgrade ctions/checkout and ctions/setup-node from @v4 to Node 24-native @v5.
- Remove the Node.js 20 action-runtime deprecation source from CI.
- Ignore machine-local .claude/skills/* and .codex/skills/ while preserving tracked ChaosEngine guidance and repository configuration.

Fixes #181

## Checks

- Focused workflow assertion: passed
- Focused .gitignore ignore checks: passed
- git diff --check: passed
- Independent reviews for both commits: no blocking findings
- Current-head GitHub Actions: all checks passed
- Current-head CI logs: no Node.js 20 action-runtime deprecation text
- Current-head check annotations: none

## Continuation

Head: $head

State: Ready for review on the canonical repository branch.

Blockers: Required repository approval is still pending; auto-merge is not armed.

Next action: Obtain required approval, then enable merge-commit auto-merge if authorized.