### PR TITLE
fix(test-execution): require successful browser evidence

### DIFF
--- a/src/modules/test-execution/playwright-agent.test.ts
+++ b/src/modules/test-execution/playwright-agent.test.ts
@@ -168,7 +168,7 @@ describe("Playwright MCP agent guardrails", () => {
       action: "Upload fixture",
       llm: nativeLlm(generateStructuredOutput),
       tools: testTools({
-        callTool: async () => ({ path: fixture, message: `Uploaded ${fixture}` }),
+        callTool: async () => ({ content: [{ type: "text", text: `Uploaded ${fixture}` }] }),
         listOpenTabs: async () => ["about:blank"],
       }),
       signal: new AbortController().signal,
@@ -183,6 +183,48 @@ describe("Playwright MCP agent guardrails", () => {
     for (const value of [fixture, path.basename(fixture), path.resolve("src")]) {
       expect(durable).not.toContain(value);
       expect(secondPrompt).not.toContain(value);
+    }
+  });
+
+  it("retains an MCP upload error marker while redacting fixture paths", async () => {
+    const fixture = path.resolve("src/modules/test-execution/playwright-agent.ts");
+    const decisions = [
+      { kind: "tool_call", toolName: "browser_file_upload", arguments: { paths: [fixture] }, reason: "Upload fixture" },
+      { kind: "complete", outcome: "error", summary: "Upload failed." },
+    ];
+    const generateStructuredOutput = vi.fn(async (_input: { user: string }) => ({ validatedOutput: decisions.shift() }));
+    const events: unknown[] = [];
+
+    await executeTestStepWithAgent({
+      action: "Upload fixture",
+      llm: nativeLlm(generateStructuredOutput),
+      tools: testTools({
+        callTool: async () => ({
+          content: [{ type: "text", text: `Could not upload ${fixture}` }],
+          isError: true,
+        }),
+        listOpenTabs: async () => ["about:blank"],
+      }),
+      signal: new AbortController().signal,
+      toolPolicy: {
+        transport: "stdio", allowAllOrigins: false, allowedNavigationOrigins: httpPolicy.allowedNavigationOrigins,
+        uploadRoots: [path.resolve("src")],
+      },
+      maxTurns: 2,
+      onEvent: (event) => { events.push(event); },
+    });
+
+    const durable = JSON.stringify(events);
+    const secondPrompt = JSON.parse(generateStructuredOutput.mock.calls[1]![0].user);
+    const serializedSecondPrompt = JSON.stringify(secondPrompt);
+    expect(events[0]).toMatchObject({
+      kind: "tool_call",
+      result: { status: "upload_result_redacted", isError: true },
+    });
+    expect(secondPrompt.observations[0].result).toEqual({ status: "upload_result_redacted", isError: true });
+    for (const value of [fixture, path.basename(fixture), path.resolve("src")]) {
+      expect(durable).not.toContain(value);
+      expect(serializedSecondPrompt).not.toContain(value);
     }
   });
 
@@ -283,7 +325,7 @@ describe("Playwright MCP agent guardrails", () => {
       { name: "complete_test_step", arguments: { outcome: "passed", summary: "Observed page." } },
     ];
     const generateToolCall = vi.fn(async (_input: unknown) => ({ toolCall: toolCalls.shift() }));
-    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "page" }] }));
+    const callTool = vi.fn(async () => ({ content: [{ type: "text" as const, text: "page" }] }));
 
     await expect(executeTestStepWithAgent({
       action: "Verify the page",
@@ -301,6 +343,94 @@ describe("Playwright MCP agent guardrails", () => {
       expect.objectContaining({ name: "browser_snapshot" }),
       expect.objectContaining({ name: "complete_test_step" }),
     ]));
+  });
+
+  it("does not count MCP error results as browser evidence", async () => {
+    const toolCalls = [
+      { name: "browser_snapshot", arguments: {} },
+      { name: "complete_test_step", arguments: { outcome: "passed", summary: "Observed page." } },
+    ];
+    const generateToolCall = vi.fn(async (_input: unknown) => ({ toolCall: toolCalls.shift() }));
+    const errorResult = {
+      content: [{ type: "text" as const, text: "Timeout waiting for locator" }],
+      isError: true,
+    };
+    const callTool = vi.fn(async () => errorResult);
+
+    await expect(executeTestStepWithAgent({
+      action: "Verify the page",
+      llm: { generateToolCall } as unknown as LLMProvider,
+      tools: {
+        callTool,
+        listOpenTabs: async () => ["https://example.com/app"],
+        toolDefinitions: [{ name: "browser_snapshot", description: "Inspect page.", inputSchema: { type: "object", properties: {} } }],
+      },
+      signal: new AbortController().signal,
+      toolPolicy: httpPolicy,
+      maxTurns: 2,
+    })).resolves.toMatchObject({ outcome: "timeout", turns: 2 });
+
+    const secondPrompt = JSON.parse((generateToolCall.mock.calls[1]?.[0] as { user: string }).user);
+    expect(secondPrompt.observations).toEqual([{
+      toolName: "browser_snapshot",
+      arguments: {},
+      result: errorResult,
+    }]);
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows an error completion after an MCP tool error", async () => {
+    const toolCalls = [
+      { name: "browser_snapshot", arguments: {} },
+      { name: "complete_test_step", arguments: { outcome: "error", summary: "Browser snapshot failed." } },
+    ];
+    const generateToolCall = vi.fn(async (_input: unknown) => ({ toolCall: toolCalls.shift() }));
+    const callTool = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "Timeout waiting for locator" }],
+      isError: true,
+    }));
+
+    await expect(executeTestStepWithAgent({
+      action: "Verify the page",
+      llm: { generateToolCall } as unknown as LLMProvider,
+      tools: {
+        callTool,
+        listOpenTabs: async () => ["https://example.com/app"],
+        toolDefinitions: [{ name: "browser_snapshot", description: "Inspect page.", inputSchema: { type: "object", properties: {} } }],
+      },
+      signal: new AbortController().signal,
+      toolPolicy: httpPolicy,
+      maxTurns: 2,
+    })).resolves.toMatchObject({ outcome: "error", summary: "Browser snapshot failed.", turns: 2 });
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows passed completion after an MCP error is followed by a successful browser result", async () => {
+    const toolCalls = [
+      { name: "browser_snapshot", arguments: {} },
+      { name: "browser_snapshot", arguments: {} },
+      { name: "complete_test_step", arguments: { outcome: "passed", summary: "Observed page." } },
+    ];
+    const generateToolCall = vi.fn(async (_input: unknown) => ({ toolCall: toolCalls.shift() }));
+    const callTool = vi.fn()
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "Timeout waiting for locator" }],
+        isError: true,
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Page snapshot" }] });
+
+    await expect(executeTestStepWithAgent({
+      action: "Verify the page",
+      llm: { generateToolCall } as unknown as LLMProvider,
+      tools: {
+        callTool,
+        listOpenTabs: async () => ["https://example.com/app"],
+        toolDefinitions: [{ name: "browser_snapshot", description: "Inspect page.", inputSchema: { type: "object", properties: {} } }],
+      },
+      signal: new AbortController().signal,
+      toolPolicy: httpPolicy,
+    })).resolves.toMatchObject({ outcome: "passed", summary: "Observed page.", turns: 3 });
+    expect(callTool).toHaveBeenCalledTimes(2);
   });
 
   it("names the provider and model when complete_test_step arguments are malformed", async () => {
@@ -333,7 +463,7 @@ describe("Playwright MCP agent guardrails", () => {
     const generateStructuredOutput = vi.fn(async () => ({ validatedOutput: decisions.shift() }));
     const onEvent = vi.fn();
     const tools = {
-      callTool: vi.fn(async () => ({ content: [{ type: "text", text: "redirected page contents" }] })),
+      callTool: vi.fn(async () => ({ content: [{ type: "text" as const, text: "redirected page contents" }] })),
       listOpenTabs: vi.fn()
         .mockResolvedValueOnce(["about:blank"])
         .mockResolvedValueOnce(["https://example.com/login"])
@@ -430,7 +560,7 @@ describe("Playwright MCP agent guardrails", () => {
     const result = await executeTestStepWithAgent({
       action: "Open the page", expectedResult: "Heading is visible", llm,
       tools: testTools({
-        callTool: async (name) => { calls.push(name); return { heading: "Example" }; },
+        callTool: async (name) => { calls.push(name); return { content: [{ type: "text", text: "Example" }] }; },
         listOpenTabs: async () => ["https://example.com"],
       }),
       signal: new AbortController().signal, toolPolicy: httpPolicy,
@@ -443,7 +573,7 @@ describe("Playwright MCP agent guardrails", () => {
     const llm = nativeLlm(async () => ({ validatedOutput: { kind: "tool_call", toolName: "browser_snapshot", arguments: {}, reason: "Inspect" } }));
     const result = await executeTestStepWithAgent({
       action: "Inspect", llm,
-      tools: testTools({ callTool: async () => ({}), listOpenTabs: async () => ["https://example.com"] }),
+      tools: testTools({ callTool: async () => ({ content: [] }), listOpenTabs: async () => ["https://example.com"] }),
       signal: new AbortController().signal, toolPolicy: httpPolicy, maxTurns: 2,
     });
     expect(result).toEqual({ outcome: "timeout", summary: "Step exceeded the 2-turn agent limit.", turns: 2 });
@@ -687,7 +817,7 @@ describe("PlaywrightAgentDecision normalization", () => {
     await executeTestStepWithAgent({
       action: "Verify",
       llm: { generateToolCall } as unknown as LLMProvider,
-      tools: testTools({ callTool: vi.fn(), listOpenTabs: async () => ["https://example.com"] }),
+      tools: testTools({ callTool: vi.fn(async () => ({ content: [] })), listOpenTabs: async () => ["https://example.com"] }),
       signal: new AbortController().signal,
       toolPolicy: httpPolicy,
     });

--- a/src/modules/test-execution/playwright-agent.ts
+++ b/src/modules/test-execution/playwright-agent.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { LLMProvider, LLMToolDefinition } from "@/modules/llm/llm-types";
 
@@ -186,8 +187,10 @@ function auditableToolArguments(name: string, args: Record<string, unknown>): Re
   return { paths: args.paths.map(() => "[fixture]") };
 }
 
-function auditableToolResult(name: string, result: unknown): unknown {
-  return name === "browser_file_upload" ? { status: "upload_result_redacted" } : result;
+function auditableToolResult(name: string, result: CallToolResult): unknown {
+  return name === "browser_file_upload"
+    ? { status: "upload_result_redacted", ...(result.isError === true ? { isError: true } : {}) }
+    : result;
 }
 
 const AgentDecisionSchema = z.discriminatedUnion("kind", [
@@ -305,7 +308,7 @@ const COMPLETE_TEST_STEP_TOOL: LLMToolDefinition = {
 };
 
 export type PlaywrightToolClient = {
-  callTool(name: string, args: Record<string, unknown>, signal: AbortSignal): Promise<unknown>;
+  callTool(name: string, args: Record<string, unknown>, signal: AbortSignal): Promise<CallToolResult>;
   listOpenTabs(signal: AbortSignal): Promise<PlaywrightBrowserTab[]>;
   toolDefinitions: readonly LLMToolDefinition[];
 };
@@ -360,7 +363,8 @@ export async function executeTestStepWithAgent(input: {
     }
   });
   if (!browserTools.length) throw new Error("Playwright MCP server did not advertise any allowlisted browser tools.");
-  let browserToolCalls = 0;
+  let browserToolAttempts = 0;
+  let successfulBrowserToolCalls = 0;
   for (let turn = 1; turn <= maxTurns; turn += 1) {
     if (input.signal.aborted) return { outcome: "cancelled", summary: "Execution was cancelled.", turns: turn - 1 };
     const tabs = await currentTabs();
@@ -391,11 +395,15 @@ export async function executeTestStepWithAgent(input: {
         );
       }
       const completion = parsedCompletion.data;
-      if (!browserToolCalls) {
+      if (!browserToolAttempts || (completion.outcome === "passed" && !successfulBrowserToolCalls)) {
         transcript.push({
           toolName: COMPLETE_TEST_STEP_TOOL.name,
           arguments: completion,
-          result: { error: "Run an allowlisted browser tool before completing the step." },
+          result: {
+            error: browserToolAttempts
+              ? "Run a successful allowlisted browser tool before passing the step."
+              : "Run an allowlisted browser tool before completing the step.",
+          },
         });
         continue;
       }
@@ -410,7 +418,7 @@ export async function executeTestStepWithAgent(input: {
     }
     const args = await validatePlaywrightToolArguments(value.name, value.arguments, input.toolPolicy);
     await currentTabs();
-    let result: unknown;
+    let result: CallToolResult;
     try {
       result = await input.tools.callTool(value.name, args, input.signal);
     } catch (error) {
@@ -426,7 +434,8 @@ export async function executeTestStepWithAgent(input: {
     await currentTabs();
     const auditableArguments = auditableToolArguments(value.name, args);
     const auditableResult = auditableToolResult(value.name, result);
-    browserToolCalls += 1;
+    browserToolAttempts += 1;
+    if (result.isError !== true) successfulBrowserToolCalls += 1;
     transcript.push({ toolName: value.name, arguments: auditableArguments, result: auditableResult });
     await input.onEvent?.({ kind: "tool_call", toolName: value.name, arguments: auditableArguments, result: auditableResult });
   }

--- a/src/modules/test-execution/playwright-execution-job.test.ts
+++ b/src/modules/test-execution/playwright-execution-job.test.ts
@@ -71,7 +71,7 @@ function jobContext() {
 }
 
 function primeHappyRun(input: { screenshotPolicy: string; agentOutcomes: Array<{ outcome: string; summary: string }>; headless?: boolean; viewportWidth?: number; viewportHeight?: number }) {
-  const callTool = vi.fn(async (..._args: unknown[]) => ({ content: [] as unknown[] }));
+  const callTool = vi.fn(async (..._args: unknown[]): Promise<{ content: unknown[]; isError?: boolean }> => ({ content: [] }));
   resolvePlaywrightMcpConfig.mockResolvedValue({ status: "configured", transport: "stdio", endpoint: null, artifactBaseUrl: null, bearerToken: null });
   // jsonb round-trips reorder object keys — the mock mimics that so a regression
   // to stringify-equality drift checking fails here.
@@ -177,6 +177,27 @@ describe("Playwright execution job", () => {
     validateToolArguments.mockRejectedValueOnce(new Error("Playwright navigation URL is not on an allowed origin."));
     await runPlaywrightExecutionJob(job, jobContext());
     expect(callTool.mock.calls.filter((call) => call[0] === "browser_resize")).toHaveLength(0);
+  });
+
+  it("fails the case when Base URL navigation resolves with an MCP tool error", async () => {
+    const { callTool } = primeHappyRun({ screenshotPolicy: "none", agentOutcomes: [] });
+    callTool.mockResolvedValueOnce({
+      content: [{ type: "text", text: "Timeout opening Base URL" }],
+      isError: true,
+    });
+
+    await runPlaywrightExecutionJob(job, jobContext());
+
+    expect(callTool.mock.calls.filter((call) => call[0] === "browser_resize")).toHaveLength(0);
+    expect(executeTestStepWithAgent).not.toHaveBeenCalled();
+    expect(markStepStarted).not.toHaveBeenCalled();
+    expect(skipRemainingQueuedSteps).toHaveBeenCalledWith("c1");
+    expect(finishCase).toHaveBeenCalledWith(
+      "c1",
+      "error",
+      "The browser could not open the Base URL before the first step.",
+      ["S3cret!Value"],
+    );
   });
 
   it("skips remaining queued steps when the first step throws a schema-validation error", async () => {

--- a/src/modules/test-execution/playwright-execution-job.ts
+++ b/src/modules/test-execution/playwright-execution-job.ts
@@ -122,7 +122,8 @@ export const runPlaywrightExecutionJob: JobHandler = async (job, context) => {
         if (settings?.baseUrl && steps.length) {
           try {
             const navigateArgs = await validatePlaywrightToolArguments("browser_navigate", { url: settings.baseUrl }, toolPolicy);
-            await connection.tools.callTool("browser_navigate", navigateArgs, context.signal);
+            const navigateResult = await connection.tools.callTool("browser_navigate", navigateArgs, context.signal);
+            if (navigateResult.isError === true) throw new Error("Playwright MCP Base URL navigation failed.");
           } catch (error) {
             outcome = context.signal.aborted ? "cancelled" : "error";
             errorMessage = error instanceof Error && /allowed origin/i.test(error.message)

--- a/src/modules/test-execution/playwright-mcp-client.ts
+++ b/src/modules/test-execution/playwright-mcp-client.ts
@@ -196,7 +196,7 @@ export async function connectPlaywrightMcp(config: ResolvedPlaywrightMcpConfig, 
       async callTool(name, args, signal) {
         assertAllowedPlaywrightTool(name);
         if (!approved.has(name)) throw new Error(`Playwright MCP server does not advertise tool "${name}".`);
-        return client.callTool({ name, arguments: withoutModelFilename(args) }, undefined, { signal });
+        return await client.callTool({ name, arguments: withoutModelFilename(args) }, undefined, { signal }) as CallToolResult;
       },
       async listOpenTabs(signal) {
         const result = await client.callTool(


### PR DESCRIPTION
## Summary
- Treat MCP tool results with isError: true as recoverable error observations, not successful browser evidence.
- Require at least one successful browser result before accepting complete_test_step with outcome: passed, while preserving failed, blocked, and error completion after an attempted browser call.
- Fail required Base URL navigation when Playwright MCP returns a resolved tool error.
- Preserve upload error status in the agent transcript without exposing fixture paths.

Follow-up to the unresolved correctness finding on #204.

## Checks
- npx vitest run --config vitest.unit.config.ts src/modules/llm/providers/provider-http.test.ts src/modules/test-execution/playwright-agent.test.ts src/modules/test-execution/playwright-mcp-client.test.ts src/modules/test-execution/playwright-execution-job.test.ts — 4 files, 122 passed.
- npm run typecheck — passed.
- GitHub CI — verify, Unit & coverage, and PostgreSQL integration passed.
- Two independent adversarial review rounds across correctness, reproduction, and blast-radius/security lenses; final round reported zero blocking findings.
- Immutable exact-head review of 6b275f267fc81e33c9ca25fb99c3b6ed7ab7e23d against d6c3ffede8d858f8625392fc4ff8c3de64c2cede reported zero blocking findings.

## Continuation
Head: 6b275f267fc81e33c9ca25fb99c3b6ed7ab7e23d
State: Exact PR head and closing reference verified; all CI checks are green; no GitHub comments or reviews are pending; independent exact-head review found zero blockers.
Blockers: Awaiting maintainer review and merge authorization.
Next action: Maintainer reviews and merges when ready.

Closes #201