### PR TITLE
fix: move local skill ignores out of the ChaosEngine-managed block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,12 +73,8 @@ graphify-out/
 !.claude/
 !.claude/**
 .claude/settings.local.json
-/.claude/skills/*
-!/.claude/skills/chaos-engine/
-!/.claude/skills/chaos-engine/**
 !.codex/
 !.codex/**
-/.codex/skills/
 !.grok/
 !.grok/hooks/
 !.grok/hooks/*.json
@@ -107,3 +103,9 @@ graphify-out/
 !.gitattributes
 .chaos-engine-owned-directory
 # CHAOSENGINE-RUNTIME:END
+
+# Local agent skill directories (kept outside the ChaosEngine-managed block)
+/.claude/skills/*
+!/.claude/skills/chaos-engine/
+!/.claude/skills/chaos-engine/**
+/.codex/skills/


### PR DESCRIPTION
Commit b6fadbc6 inserted the /.claude/skills/* and /.codex/skills/ ignore rules inside the CHAOSENGINE-RUNTIME:START/END block. The ChaosEngine host controller verifies that block byte-exact, so any foreign line makes hosts.install() raise "gitignore collision" and install.py status/doctor fail with "host receipt is missing or invalid", blocking receipt creation and dependency provisioning.

Move the four rules below the END marker. Ignore semantics are unchanged (chaos-engine skill adapters stay tracked, all other local skill directories stay ignored), but the lines now live outside installer-owned territory so future ChaosEngine upgrades cannot collide with them. Verified: install.py doctor reports healthy.